### PR TITLE
fix: tutorial deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click
 comm
 contourpy
 cycler
-datasets
+datasets >=2.20.0
 debugpy
 decorator
 dill
@@ -90,7 +90,7 @@ torch
 tornado
 tqdm
 traitlets
-transformer-lens
+transformer-lens >=2.16
 transformers
 transformers-stream-generator
 typeguard


### PR DESCRIPTION
1. **datasets:** Fixes huggingface/datasets#7742
2. **transformer-lens:** Bumps to `>=2.16.0` to fix `transformers` v5 compatibility.
    * Deprecation in `transformers`: [hub.py](https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/utils/hub.py#L108-L111)
    * Breakage in `transformer-lens<2.16`: [utils.py](https://github.com/TransformerLensOrg/TransformerLens/blob/v2.15.4/transformer_lens/utils.py#L31)
    * Upstream fix: [utils.py](https://github.com/TransformerLensOrg/TransformerLens/blob/v2.16.0/transformer_lens/utils.py#L33)